### PR TITLE
Fix startup position

### DIFF
--- a/main.py
+++ b/main.py
@@ -817,9 +817,6 @@ async def main():
 
     await client.run_until_disconnected()
 
-if __name__ == "__main__":
-    asyncio.run(main())
-
 
 @client.on(events.NewMessage(pattern=r'^\.معلومات(?:\s+(.*))?$'))
 async def user_info(event):
@@ -889,3 +886,6 @@ async def leave_group(event):
         await client(functions.channels.LeaveChannelRequest(chat.id))
     except Exception as e:
         await event.reply(f"❌ فشل المغادرة: {str(e)}")
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- move `asyncio.run(main())` to end of `main.py` so all handlers load first

## Testing
- `python3 -m py_compile main.py`
- `python3 main.py` *(fails: ModuleNotFoundError: No module named 'telethon')*

------
https://chatgpt.com/codex/tasks/task_e_6883fd8dcf548320987ff2c56352b210