### PR TITLE
Add pytest tests for baghdad_time

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # telegram_userbot
+
+## Running Tests
+
+After installing the project dependencies you can run the automated tests with [pytest](https://pytest.org/):
+
+```bash
+pip install -r requirements.txt
+pip install pytest
+pytest
+```

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,8 @@
+import datetime
+
+from main import baghdad_time
+
+
+def test_baghdad_time_default():
+    expected = (datetime.datetime.utcnow() + datetime.timedelta(hours=3)).strftime("%I:%M %p")
+    assert baghdad_time() == expected


### PR DESCRIPTION
## Summary
- add simple pytest infrastructure under `tests/`
- provide a test that validates `baghdad_time`
- document how to run the tests in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'telethon')*

------
https://chatgpt.com/codex/tasks/task_e_6883fd8f49588320b590dd3bafd9a26e