### PR TITLE
Fix leave command history deletion for channels

### DIFF
--- a/main.py
+++ b/main.py
@@ -838,7 +838,14 @@ async def leave_group(event):
     chat = await event.get_chat()
     try:
         input_peer = await event.get_input_chat()
-        await client(functions.messages.DeleteHistoryRequest(peer=input_peer, max_id=0, revoke=False))
+
+        try:
+            if event.is_channel or getattr(chat, 'megagroup', False):
+                await client(functions.channels.DeleteHistoryRequest(channel=input_peer, max_id=0))
+            else:
+                await client(functions.messages.DeleteHistoryRequest(peer=input_peer, max_id=0, revoke=False))
+        except Exception:
+            pass
 
         if event.is_channel or getattr(chat, 'megagroup', False):
             await client(functions.channels.LeaveChannelRequest(channel=input_peer))


### PR DESCRIPTION
## Summary
- fix channel leave command by using `channels.DeleteHistoryRequest`
- ignore deletion errors before leaving

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_688506716b948320adad339ced56bf6f